### PR TITLE
fix cmake deprecation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,14 +44,14 @@ jobs:
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: cache target_ws
         if: ${{ ! matrix.env.CCOV }}
-        uses: pat-s/always-upload-cache@v2.1.5
+        uses: pat-s/always-upload-cache@v3.0.11
         with:
           path: ${{ env.BASEDIR }}/target_ws
           key: target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}-${{ github.run_id }}
           restore-keys: |
             target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}
       - name: cache ccache
-        uses: pat-s/always-upload-cache@v2.1.5
+        uses: pat-s/always-upload-cache@v3.0.11
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
@@ -62,7 +62,7 @@ jobs:
         uses: 'ros-industrial/industrial_ci@master'
         env: ${{ matrix.env }}
       - name: upload test artifacts (on failure)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-results

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -15,6 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - name: Install clang-format-12
-      run: sudo apt-get install clang-format-12
+    - name: Install clang-format-14
+      run: sudo apt-get install clang-format-14
     - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -13,8 +13,8 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
     - name: Install clang-format-14
       run: sudo apt-get install clang-format-14
-    - uses: pre-commit/action@v2.0.3
+    - uses: pre-commit/action@v3.0.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(graph_msgs)
 
 # Default to C++14


### PR DESCRIPTION
cmake version < then 3.10 is deprecated
the oldest ros distribution in development is humble. this requires cmake >=3.8 and gcc 17